### PR TITLE
Zmw/fixing ascii quote

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -5,6 +5,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
   <title>{{meta_title}}</title>
+  <meta name="description" content="{{meta_description}}" />
+
   <meta name="HandheldFriendly" content="True" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/default.hbs
+++ b/default.hbs
@@ -5,8 +5,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
   <title>{{meta_title}}</title>
-  <meta name="description" content="{{meta_description}}" />
-
   <meta name="HandheldFriendly" content="True" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -10,7 +10,7 @@
           {{#author}}
           <li>
             {{#if profile_image}}
-            <a class="author-image" href="{{url}}" style="background-image: url({{img_url profile_image}})”><span class="hidden">{{name}}'s Picture</span></a>
+            <a class="author-image" href="{{url}}" style="background-image: url({{img_url profile_image}})"><span class="hidden">{{name}}'s Picture</span></a>
             {{else}}
             <i class="fa fa-user"></i>
             {{/if}}


### PR DESCRIPTION
This comma is not the right ascii comma we want. Here is a screen shot of the error with the autho's profile pic, which does exist. I found the funky comma by drilling into the develop console. This patch fixes it, verified. This shows up when using Ghost 1.0+

<img width="1015" alt="screen shot 2017-08-05 at 8 19 27 pm" src="https://user-images.githubusercontent.com/538171/29000336-3def3582-7a1c-11e7-8706-f52fc9a5b739.png">
